### PR TITLE
scsi: sd: Fix typo in sd_first_printk()

### DIFF
--- a/drivers/scsi/sd.h
+++ b/drivers/scsi/sd.h
@@ -133,7 +133,7 @@ static inline struct scsi_disk *scsi_disk(struct gendisk *disk)
 
 #define sd_first_printk(prefix, sdsk, fmt, a...)			\
 	do {								\
-		if ((sdkp)->first_scan)					\
+		if ((sdsk)->first_scan)					\
 			sd_printk(prefix, sdsk, fmt, ##a);		\
 	} while (0)
 


### PR DESCRIPTION
added the macro sd_first_printk(). The macro takes "sdsk" as argument but dereferences "sdkp". This hasn't caused any real issues since all callers of sd_first_printk() have an sdkp. But fix the typo.

Signed-off-by: Li kunyu <kunyu@nfschina.com>